### PR TITLE
Fix after not showing when not truncated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dotdotdot",
+  "version": "1.7.3",
+  "description": "A jQuery plugin for advanced cross-browser ellipsis on multiple line content.",
+  "homepage": "http://dotdotdot.frebsite.nl/",
+  "author": {
+    "name": "Fred Heusschen",
+    "email": "info@frebsite.nl"
+  },
+  "dependencies": {
+    "jquery": ">= 1.4.3"
+  }
+}

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -156,7 +156,7 @@
 
 			).bind(
 				'destroy.dot',
-				function( e )
+				function( e, fn )
 				{
 					e.preventDefault();
 					e.stopPropagation();
@@ -169,6 +169,10 @@
 						.append( orgContent )
 						.attr( 'style', $dot.data( 'dotdotdot-style' ) || '' )
 						.data( 'dotdotdot', false );
+					if ( typeof fn == 'function' )
+					{
+						fn.call( $dot[ 0 ] );
+					}
 				}
 			);
 			return $dot;

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -395,9 +395,16 @@
 
 							if ( !isTruncated )
 							{
+								// force truncation of last text node within $e
 								var lastTextNode = findLastTextNode( $e, $d );
-								if (lastTextNode) ellipsisElement( $( lastTextNode ), $d, $i, o, after );
-								addAfter( $e );
+								if ( lastTextNode ) ellipsisElement( $( lastTextNode ), $d, $i, o, after );
+
+								// if $e contains that last text node, then we want after link immediately after it
+								if ( $.contains( $e[0], lastTextNode ) ) {
+									addAfter( $e );
+								} else {
+									addAfter( $elem );
+								}
 								isTruncated = true;
 							}
 						}

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -359,8 +359,8 @@
 					var e	= this,
 						$e	= $(e);
 
-					var addAfter = function(elem) {
-						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
+					var addAfter = function( elem ) {
+						if ( after )
 						{
 							elem[ elem.is( notx ) ? 'after' : 'append' ]( after );
 						}

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -395,8 +395,8 @@
 
 							if ( !isTruncated )
 							{
-								var txt = addEllipsis( getTextContent( e ), o );
-								setTextContent( e, txt );
+								var lastTextNode = findLastTextNode( $e, $d );
+								if (lastTextNode) ellipsisElement( $( lastTextNode ), $d, $i, o, after );
 								addAfter( $e );
 								isTruncated = true;
 							}

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -1,5 +1,5 @@
 /*
- *	jQuery dotdotdot 1.7.2
+ *	jQuery dotdotdot 1.7.3
  *
  *	Copyright (c) Fred Heusschen
  *	www.frebsite.nl

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -355,6 +355,13 @@
 					var e	= this,
 						$e	= $(e);
 
+					var addAfter = function(elem) {
+						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
+						{
+							elem[ elem.is( notx ) ? 'after' : 'append' ]( after );
+						}
+					};
+
 					if ( typeof e == 'undefined' || ( e.nodeType == 3 && $.trim( e.data ).length == 0 ) )
 					{
 						return true;
@@ -370,10 +377,7 @@
 					else
 					{
 						$elem.append( $e );
-						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
-						{
-							$elem[ $elem.is( notx ) ? 'after' : 'append' ]( after );
-						}
+						addAfter( $elem );
 						if ( test( $i, o ) )
 						{
 							if ( e.nodeType == 3 ) // node is TEXT
@@ -387,7 +391,9 @@
 
 							if ( !isTruncated )
 							{
-								$e.detach();
+								var txt = addEllipsis( getTextContent( e ), o );
+								setTextContent( e, txt );
+								addAfter( $e );
 								isTruncated = true;
 							}
 						}


### PR DESCRIPTION
This addresses problems with the fixes from [this branch](https://github.com/swergas/jQuery.dotdotdot/tree/fix-paragraph-and-read-more-not-showing):
- Preserves markup on if ellipsis is added to the last element in some cases where the container had caused the height to be exceeded.
- Avoids errors with `!$e.is( o.after ) && !$e.find( o.after ).length`
